### PR TITLE
Duplicate select options

### DIFF
--- a/dist/dual-list-box.js
+++ b/dist/dual-list-box.js
@@ -93,13 +93,17 @@
                     text = item[options.text];
                 }
 
-                $('<option>', {
-                    value: item[options.value],
-                    text: text,
-                    selected: (selected.some(function (e) { return e[options.value] === item[options.value] }) === true)
-                }).appendTo(options.element);
+                var isSelected = (selected.some(function (e) { return e[options.value] === item[options.value] }) === true);
+                if (!isSelected) {
+                    $('<option>', {
+                        value: item[options.value],
+                        text: text,
+                        selected: isSelected
+                    }).appendTo(options.element);
+                } else { // is already in the options list
+                    $(options.element).find("option[value=" + item[options.value] + "]").attr("selected", true);
+                }
             });
-
             construct(options);
         });
     }


### PR DESCRIPTION
If selected list is supplied, the element must only be in the selectecd box and not in both lists
